### PR TITLE
[DOCS] Switch to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -46,3 +46,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
+          cname: composer-update-check.elias-haeussler.de

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -40,16 +40,9 @@ jobs:
           name: rendered-docs
           path: site/
 
-      # Prepare SSH connection
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          known_hosts: ${{ secrets.KNOWN_HOSTS }}
-
       # Upload
       - name: Deploy
-        run: |
-          rsync -avz --chmod=Du=rwx,Dgo=rx,Fu=rw,Fog=r \
-            ${{ steps.download.outputs.download-path }}/ \
-            ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:/home/eliashae/html/docs.elias-haeussler.de/composer-update-check/
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Total Downloads](http://poser.pugx.org/eliashaeussler/composer-update-check/downloads)](https://packagist.org/packages/eliashaeussler/composer-update-check)
 [![License](http://poser.pugx.org/eliashaeussler/composer-update-check/license)](LICENSE.md)
 
-**:orange_book:&nbsp;[Documentation](https://docs.elias-haeussler.de/composer-update-check/)** |
+**:orange_book:&nbsp;[Documentation](https://composer-update-check.elias-haeussler.de/)** |
 :package:&nbsp;[Packagist](https://packagist.org/packages/eliashaeussler/composer-update-check) |
 :floppy_disk:&nbsp;[Repository](https://github.com/eliashaeussler/composer-update-check) |
 :bug:&nbsp;[Issue tracker](https://github.com/eliashaeussler/composer-update-check/issues)

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "support": {
     "issues": "https://github.com/eliashaeussler/composer-update-check/issues",
     "source": "https://github.com/eliashaeussler/composer-update-check",
-    "docs": "https://docs.elias-haeussler.de/composer-update-check/",
+    "docs": "https://composer-update-check.elias-haeussler.de/",
     "rss": "https://github.com/eliashaeussler/composer-update-check/releases.atom"
   },
   "require": {

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,9 @@ hide:
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=eliashaeussler_composer-update-check&metric=coverage)](https://sonarcloud.io/dashboard?id=eliashaeussler_composer-update-check)
 [![Tests](https://github.com/eliashaeussler/composer-update-check/actions/workflows/tests.yaml/badge.svg)](https://github.com/eliashaeussler/composer-update-check/actions/workflows/tests.yaml)
 [![CGL](https://github.com/eliashaeussler/composer-update-check/actions/workflows/cgl.yaml/badge.svg)](https://github.com/eliashaeussler/composer-update-check/actions/workflows/cgl.yaml)
-[![Latest Stable Version](http://poser.pugx.org/eliashaeussler/composer-update-check/v)](https://packagist.org/packages/eliashaeussler/composer-update-check)
-[![Total Downloads](http://poser.pugx.org/eliashaeussler/composer-update-check/downloads)](https://packagist.org/packages/eliashaeussler/composer-update-check)
-[![License](http://poser.pugx.org/eliashaeussler/composer-update-check/license)](license.md)
+[![Latest Stable Version](https://poser.pugx.org/eliashaeussler/composer-update-check/v)](https://packagist.org/packages/eliashaeussler/composer-update-check)
+[![Total Downloads](https://poser.pugx.org/eliashaeussler/composer-update-check/downloads)](https://packagist.org/packages/eliashaeussler/composer-update-check)
+[![License](https://poser.pugx.org/eliashaeussler/composer-update-check/license)](license.md)
 
 # Composer update check plugin
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,7 +82,8 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.tasklist:
       custom_checkbox: true
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.snippets
   - pymdownx.superfences
   - pymdownx.highlight:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,7 @@ extra:
     url: https://github.com/eliashaeussler/composer-update-check
     blob: https://github.com/eliashaeussler/composer-update-check/tree/master
   social:
-    - icon: fontawesome/solid/globe-americas
+    - icon: fontawesome/solid/earth-americas
       link: https://haeussler.dev
     - icon: fontawesome/brands/twitter
       link: https://haeussler.dev/twitter

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 # Site configuration
 site_name: Composer update check plugin
-site_url: https://docs.elias-haeussler.de/composer-update-check/
+site_url: https://composer-update-check.elias-haeussler.de/
 site_description: Documentation of Composer Plugin "eliashaeussler/composer-update-check"
 site_author: Elias Häußler
 


### PR DESCRIPTION
This PR replaces the legacy documentation server with GitHub Pages. For this, the branch `gh-pages` has been added.