### PR TITLE
[FEATURE] Parameterize PHP version in Docker container

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -153,11 +153,12 @@ jobs:
 
   # Job: Run Docker tests
   tests-docker:
-    name: '[test-docker] Composer ${{ matrix.composer-version }}'
+    name: '[test-docker] PHP ${{ matrix.php-version }} & Composer ${{ matrix.composer-version }}'
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
+        php-version: ["7.1", "7.2", "7.3", "7.4", "8.0"]
         composer-version: ["1", "2"]
     steps:
       - uses: actions/checkout@v2
@@ -166,7 +167,7 @@ jobs:
 
       # Run tests
       - name: Run tests
-        run: ./bin/run-docker-tests.sh --composer-version "${{ matrix.composer-version }}"
+        run: ./bin/run-docker-tests.sh --composer-version "${{ matrix.composer-version }}" --php-version "${{ matrix.php-version }}"
 
   # Job: Run unit tests of composer-update-reporter
   tests-reporter:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM php:7.4-alpine
+ARG PHP_VERSION=7.4
+FROM php:${PHP_VERSION}-alpine
 LABEL maintainer="Elias Häußler <elias@haeussler.dev>"
 
 ARG COMPOSER_VERSION=2

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -54,6 +54,9 @@ images. All available parameters for the `update-check` command can be passed.
 # Run tests for the Docker image using Composer 2.x
 ./bin/run-docker-tests.sh --composer-version 2
 
+# Run tests for the Docker image using Composer 2.x and PHP 8.0
+./bin/run-docker-tests.sh --composer-version 2 --php-version "8.0"
+
 # Run tests with optional parameters
 ./bin/run-docker-tests.sh --composer-version 2 --security-scan --no-dev
 ```


### PR DESCRIPTION
This PR enables to define a PHP version when building the Docker container. This is especially useful for automated tests in CI, but it also paves the way to a more modern Docker performance.