### PR TITLE
[TASK] Define "allow-plugins" in test applications (Composer 2.2)

### DIFF
--- a/tests/Build/test-application-empty/composer.json
+++ b/tests/Build/test-application-empty/composer.json
@@ -1,4 +1,9 @@
 {
   "require": {},
-  "require-dev": {}
+  "require-dev": {},
+  "config": {
+    "allow-plugins": {
+      "eliashaeussler/composer-update-check": true
+    }
+  }
 }

--- a/tests/Build/test-application/v7/composer.json
+++ b/tests/Build/test-application/v7/composer.json
@@ -5,5 +5,10 @@
   },
   "require-dev": {
     "codeception/codeception": "^4.1"
+  },
+  "config": {
+    "allow-plugins": {
+      "eliashaeussler/composer-update-check": true
+    }
   }
 }

--- a/tests/Build/test-application/v8/composer.json
+++ b/tests/Build/test-application/v8/composer.json
@@ -5,5 +5,10 @@
   },
   "require-dev": {
     "codeception/codeception": "^4.1"
+  },
+  "config": {
+    "allow-plugins": {
+      "eliashaeussler/composer-update-check": true
+    }
   }
 }


### PR DESCRIPTION
Since Composer 2.2, plugins must be explicitly marked inside "allowed-plugins". Therefore, this config is now added to all test applications that are used for testing purposes.