### PR TITLE
[BUGFIX] Exclude packages without advisories from security scan result

### DIFF
--- a/src/Security/ScanResult.php
+++ b/src/Security/ScanResult.php
@@ -65,12 +65,17 @@ class ScanResult
         // Parse security advisories
         $insecurePackages = [];
         $advisories = $apiResult['advisories'];
+
         foreach ($advisories as $packageName => $packageAdvisories) {
             $affectedVersions = [];
+
             foreach ($packageAdvisories as $packageAdvisory) {
                 $affectedVersions[] = $packageAdvisory['affectedVersions'];
             }
-            $insecurePackages[] = new InsecurePackage($packageName, $affectedVersions);
+
+            if ([] !== $affectedVersions) {
+                $insecurePackages[] = new InsecurePackage($packageName, $affectedVersions);
+            }
         }
 
         return new self($insecurePackages);


### PR DESCRIPTION
Prior to this PR, packages without security advisories were added to the security scan result. This is not expected behavior and has been changed: Only packages with at least one item in `affectedVersions` are now added in `ScanResult::fromApiResult())`.