### PR TITLE
[TASK] Allow installation of spatie/emoji 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "nyholm/psr7": "^1.0",
     "psr/http-client": "^1.0",
     "psr/http-message": "^1.0",
-    "spatie/emoji": "^2.0",
+    "spatie/emoji": "^2.0 || ^3.0",
     "symfony/console": "^4.4.11 || ^5.0.11 || ^6.0",
     "symfony/http-client": "^4.4.11 || ^5.0.11 || ^6.0"
   },


### PR DESCRIPTION
This PR widens the version range of `spatie/emoji` to support 3.x versions as well.