### PR TITLE
[TASK] Drop support for `develop` branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
       interval: daily
     commit-message:
       prefix: '[TASK]'
-    target-branch: develop
     labels:
       - dependencies
     open-pull-requests-limit: 10

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - '**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,7 +308,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release
 
-[Unreleased]: https://github.com/eliashaeussler/composer-update-check/compare/1.5.0...develop
+[Unreleased]: https://github.com/eliashaeussler/composer-update-check/compare/1.5.0...main
 [1.5.0]: https://github.com/eliashaeussler/composer-update-check/compare/1.4.1...1.5.0
 [1.4.1]: https://github.com/eliashaeussler/composer-update-check/compare/1.4.0...1.4.1
 [1.4.0]: https://github.com/eliashaeussler/composer-update-check/compare/1.3.0...1.4.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Composer update check plugin
 
-[![Coverage](https://codecov.io/gh/eliashaeussler/composer-update-check/branch/develop/graph/badge.svg?token=9AEQ0LRYU0)](https://codecov.io/gh/eliashaeussler/composer-update-check)
+[![Coverage](https://codecov.io/gh/eliashaeussler/composer-update-check/branch/main/graph/badge.svg?token=9AEQ0LRYU0)](https://codecov.io/gh/eliashaeussler/composer-update-check)
 [![Maintainability](https://api.codeclimate.com/v1/badges/882ab3bb81b87d2b4a6d/maintainability)](https://codeclimate.com/github/eliashaeussler/composer-update-check/maintainability)
 [![Tests](https://github.com/eliashaeussler/composer-update-check/actions/workflows/tests.yaml/badge.svg)](https://github.com/eliashaeussler/composer-update-check/actions/workflows/tests.yaml)
 [![CGL](https://github.com/eliashaeussler/composer-update-check/actions/workflows/cgl.yaml/badge.svg)](https://github.com/eliashaeussler/composer-update-check/actions/workflows/cgl.yaml)

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ hide:
 - toc
 ---
 
-[![Coverage](https://codecov.io/gh/eliashaeussler/composer-update-check/branch/develop/graph/badge.svg?token=9AEQ0LRYU0)](https://codecov.io/gh/eliashaeussler/composer-update-check)
+[![Coverage](https://codecov.io/gh/eliashaeussler/composer-update-check/branch/main/graph/badge.svg?token=9AEQ0LRYU0)](https://codecov.io/gh/eliashaeussler/composer-update-check)
 [![Maintainability](https://api.codeclimate.com/v1/badges/882ab3bb81b87d2b4a6d/maintainability)](https://codeclimate.com/github/eliashaeussler/composer-update-check/maintainability)
 [![Tests](https://github.com/eliashaeussler/composer-update-check/actions/workflows/tests.yaml/badge.svg)](https://github.com/eliashaeussler/composer-update-check/actions/workflows/tests.yaml)
 [![CGL](https://github.com/eliashaeussler/composer-update-check/actions/workflows/cgl.yaml/badge.svg)](https://github.com/eliashaeussler/composer-update-check/actions/workflows/cgl.yaml)


### PR DESCRIPTION
With this PR, support for the `develop` branch is dropped. The `main` branch will be used as main branch in the future.