### PR TITLE
[BUGFIX] Run `composer allow-plugins` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN composer self-update --$COMPOSER_VERSION
 
 # Require update check package
 RUN composer global config repositories.update-check path /update-check
+RUN if [ "$COMPOSER_VERSION" = 2 ]; then composer global config allow-plugins.eliashaeussler/composer-update-check true; fi
 RUN composer global require --dev "eliashaeussler/composer-update-check:*@dev"
 
 WORKDIR /app


### PR DESCRIPTION
This PR adds the `composer allow-plugins` command to the `Dockerfile` to allow this Composer plugin to be installed.