### PR TITLE
[BUGFIX] Replace deprecated job outputs in GitHub workflows

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -120,9 +120,9 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - id: set-branch
-        run: echo "::set-output name=branch::${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}"
+        run: echo "branch=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}" >> $GITHUB_OUTPUT
       - id: set-sha
-        run: echo "::set-output name=sha::${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
+        run: echo "sha=${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}" >> $GITHUB_OUTPUT
       - name: Trigger workflow
         uses: benc-uk/workflow-dispatch@v1
         with:


### PR DESCRIPTION
With GitHub [deprecating the `set-output` commands in GitHub workflows](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), the new `$GITHUB_OUTPUT` variable needs to be used instead.