### PR TITLE
[BUGFIX] Fix temporary dependency constraints in CGL workflow

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -31,12 +31,14 @@ jobs:
         run: composer require composer/composer:"^1.7 || ^2.0" composer/semver:"^1.0 || ^2.0 || ^3.0" --no-update
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
+        with:
+          dependency-versions: highest
 
       # Check Composer dependencies
       - name: Check dependencies
         run: composer-require-checker check
       - name: Reset composer.json
-        run: git checkout composer.json
+        run: git checkout composer.json composer.lock
       - name: Re-install Composer dependencies
         uses: ramsey/composer-install@v2
       - name: Check for unused dependencies

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -28,7 +28,7 @@ jobs:
 
       # Install dependencies
       - name: Add required packages
-        run: composer require composer/composer:"^2.0" composer/semver:"*" --no-update
+        run: composer require composer/composer:"^2.0" composer/semver:"^1.0 || ^2.0 || ^3.0" --no-update
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
 

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -28,7 +28,7 @@ jobs:
 
       # Install dependencies
       - name: Add required packages
-        run: composer require composer/composer:"^2.0" composer/semver:"^1.0 || ^2.0 || ^3.0" --no-update
+        run: composer require composer/composer:"^1.7 || ^2.0" composer/semver:"^1.0 || ^2.0 || ^3.0" --no-update
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
 

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
   },
   "require-dev": {
     "composer/composer": "^1.7 || ^2.0",
+    "composer/semver": "^1.0 || ^2.0 || ^3.0",
     "ergebnis/composer-normalize": "^2.8",
     "friendsofphp/php-cs-fixer": ">= 2.17 < 4.0",
     "php-http/discovery": "^1.14",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4aa0eb102a8bae42442ff9748bcd3906",
+    "content-hash": "1530c1669f216991f7b264f8eabbe54f",
     "packages": [
         {
             "name": "nyholm/psr7",


### PR DESCRIPTION
`composer/composer` and `composer/semver` are now properly required and reset during CGL workflow.