### PR TITLE
[BUGFIX] Properly scope Composer Installer subprocesses

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,4 +3,4 @@ parameters:
 		-
 			message: "#^Call to function method_exists\\(\\) with Composer\\\\Installer and 'setAudit' will always evaluate to true\\.$#"
 			count: 2
-			path: src/Composer/ComposerInstaller.php
+			path: src/Composer/Installer.php

--- a/src/UpdateChecker.php
+++ b/src/UpdateChecker.php
@@ -39,7 +39,7 @@ final class UpdateChecker
 {
     public function __construct(
         private readonly \Composer\Composer $composer,
-        private readonly Composer\ComposerInstaller $installer,
+        private readonly Composer\Installer $installer,
         private readonly IO\IOInterface $io,
         private readonly Security\SecurityScanner $securityScanner,
         private readonly Reporter\ReporterFactory $reporterFactory,


### PR DESCRIPTION
This PR extends the custom Composer installer to properly scope (mock) `EventDispatcher`, `AutoloadGenerator` and local repository. This avoids unintended installations and outputs when doing internal dry-run updates.