### PR TITLE
[TASK] Drop support for Composer v2.1

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -33,7 +33,7 @@ jobs:
 
       # Install dependencies
       - name: Add required packages
-        run: composer require composer/composer:"^2.1" composer/semver:"^3.4" --no-update
+        run: composer require composer/composer:"^2.2" composer/semver:"^3.4" --no-update
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: ["8.1", "8.2", "8.3"]
-        composer-version: ["2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7"]
+        composer-version: ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7"]
         dependencies: ["highest", "lowest"]
         # Avoid incompatible interface implementations in Composer v2.6 & symfony/console v7
         include:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	"require": {
 		"php": "~8.1.0 || ~8.2.0 || ~8.3.0",
 		"ext-json": "*",
-		"composer-plugin-api": "^2.1",
+		"composer-plugin-api": "^2.2",
 		"composer/semver": "^1.0 || ^2.0 || ^3.0",
 		"cuyz/valinor": "^1.7",
 		"guzzlehttp/guzzle": "^7.0",
@@ -39,7 +39,7 @@
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^1.8 || ^2.0",
-		"composer/composer": "^2.1",
+		"composer/composer": "^2.2",
 		"eliashaeussler/php-cs-fixer-config": "^2.0",
 		"eliashaeussler/phpstan-config": "^2.4",
 		"eliashaeussler/rector-config": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b86ea29fb8faea69f55835e4df6f957c",
+    "content-hash": "583967000a4678bfce3130e8dccde889",
     "packages": [
         {
             "name": "composer/semver",
@@ -7151,8 +7151,8 @@
     "platform": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-json": "*",
-        "composer-plugin-api": "^2.1"
+        "composer-plugin-api": "^2.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 * PHP >= 8.1
-* Composer >= 2.1
+* Composer >= 2.2
 
 ## Installation
 


### PR DESCRIPTION
This PR drops support for Composer v2.1 and requires at least Composer v2.2 LTS.