### PR TITLE
[TASK] Store root package information in `UpdateCheckResult`

### DIFF
--- a/src/Entity/Report/MattermostReport.php
+++ b/src/Entity/Report/MattermostReport.php
@@ -54,18 +54,17 @@ final class MattermostReport implements JsonSerializable
         string $channel,
         ?string $username,
         Entity\Result\UpdateCheckResult $result,
-        string $rootPackageName = null,
     ): self {
         return new self(
             $channel,
-            self::createText($result, $rootPackageName),
+            self::createText($result),
             self::createAttachments($result),
             ':rotating_light:',
             $username,
         );
     }
 
-    private static function createText(Entity\Result\UpdateCheckResult $result, string $rootPackageName = null): string
+    private static function createText(Entity\Result\UpdateCheckResult $result): string
     {
         $numberOfOutdatedPackages = count($result->getOutdatedPackages());
         $numberOfInsecurePackages = count($result->getInsecureOutdatedPackages());
@@ -80,7 +79,7 @@ final class MattermostReport implements JsonSerializable
         );
 
         // Outdated packages table
-        $textParts[] = self::renderOutdatedPackagesTable($result, $rootPackageName);
+        $textParts[] = self::renderOutdatedPackagesTable($result);
 
         return implode(PHP_EOL, $textParts);
     }
@@ -102,10 +101,9 @@ final class MattermostReport implements JsonSerializable
         return $attachments;
     }
 
-    private static function renderOutdatedPackagesTable(
-        Entity\Result\UpdateCheckResult $result,
-        string $rootPackageName = null,
-    ): string {
+    private static function renderOutdatedPackagesTable(Entity\Result\UpdateCheckResult $result): string
+    {
+        $rootPackageName = $result->getRootPackage()?->getName();
         $numberOfExcludedPackages = count($result->getExcludedPackages());
         $hasInsecureOutdatedPackages = $result->hasInsecureOutdatedPackages();
         $textParts = [];

--- a/src/Entity/Report/SlackReport.php
+++ b/src/Entity/Report/SlackReport.php
@@ -47,10 +47,9 @@ final class SlackReport implements JsonSerializable
         public readonly array $blocks,
     ) {}
 
-    public static function create(
-        Entity\Result\UpdateCheckResult $result,
-        string $rootPackageName = null,
-    ): self {
+    public static function create(Entity\Result\UpdateCheckResult $result): self
+    {
+        $rootPackageName = $result->getRootPackage()?->getName();
         $remainingBlocks = self::MAX_BLOCKS;
         $remainingPackages = count($result->getOutdatedPackages());
 

--- a/src/Entity/Result/UpdateCheckResult.php
+++ b/src/Entity/Result/UpdateCheckResult.php
@@ -47,8 +47,11 @@ final class UpdateCheckResult
      * @param list<Entity\Package\OutdatedPackage> $outdatedPackages
      * @param list<Entity\Package\Package>         $excludedPackages
      */
-    public function __construct(array $outdatedPackages, array $excludedPackages = [])
-    {
+    public function __construct(
+        array $outdatedPackages,
+        array $excludedPackages = [],
+        private readonly ?Entity\Package\InstalledPackage $rootPackage = null,
+    ) {
         $this->outdatedPackages = $this->sortPackages($outdatedPackages);
         $this->excludedPackages = $this->sortPackages($excludedPackages);
     }
@@ -67,6 +70,11 @@ final class UpdateCheckResult
     public function getExcludedPackages(): array
     {
         return $this->excludedPackages;
+    }
+
+    public function getRootPackage(): ?Entity\Package\InstalledPackage
+    {
+        return $this->rootPackage;
     }
 
     /**

--- a/src/Reporter/MattermostReporter.php
+++ b/src/Reporter/MattermostReporter.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\ComposerUpdateCheck\Reporter;
 
-use Composer\Composer;
 use Composer\IO;
 use EliasHaeussler\ComposerUpdateCheck\Entity;
 use GuzzleHttp\Client;
@@ -46,7 +45,6 @@ final class MattermostReporter implements Reporter
 
     public function __construct(
         private readonly Client $client,
-        private readonly Composer $composer,
         private readonly IO\IOInterface $io,
     ) {
         $this->resolver = $this->createOptionsResolver();
@@ -56,14 +54,8 @@ final class MattermostReporter implements Reporter
     {
         ['url' => $url, 'channel' => $channel, 'username' => $username] = $this->resolver->resolve($options);
 
-        // Resolve root package name from composer.json
-        $rootPackageName = $this->composer->getPackage()->getName();
-        if ('__root__' === $rootPackageName) {
-            $rootPackageName = null;
-        }
-
         // Create report
-        $report = Entity\Report\MattermostReport::create($channel, $username, $result, $rootPackageName);
+        $report = Entity\Report\MattermostReport::create($channel, $username, $result);
 
         // Send report
         try {

--- a/src/Reporter/SlackReporter.php
+++ b/src/Reporter/SlackReporter.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\ComposerUpdateCheck\Reporter;
 
-use Composer\Composer;
 use Composer\IO;
 use EliasHaeussler\ComposerUpdateCheck\Entity;
 use GuzzleHttp\Client;
@@ -46,7 +45,6 @@ final class SlackReporter implements Reporter
 
     public function __construct(
         private readonly Client $client,
-        private readonly Composer $composer,
         private readonly IO\IOInterface $io,
     ) {
         $this->resolver = $this->createOptionsResolver();
@@ -56,14 +54,8 @@ final class SlackReporter implements Reporter
     {
         ['url' => $url] = $this->resolver->resolve($options);
 
-        // Resolve root package name from composer.json
-        $rootPackageName = $this->composer->getPackage()->getName();
-        if ('__root__' === $rootPackageName) {
-            $rootPackageName = null;
-        }
-
         // Create report
-        $report = Entity\Report\SlackReport::create($result, $rootPackageName);
+        $report = Entity\Report\SlackReport::create($result);
 
         // Send report
         try {
@@ -107,7 +99,7 @@ final class SlackReporter implements Reporter
             ->allowedTypes('string')
             ->required()
             ->normalize(
-                static fn (OptionsResolver\OptionsResolver $optionsResolver, string $url) => new Psr7\Uri($url),
+                static fn (OptionsResolver\OptionsResolver $resolver, string $url) => new Psr7\Uri($url),
             )
         ;
 

--- a/src/UpdateChecker.php
+++ b/src/UpdateChecker.php
@@ -120,7 +120,11 @@ final class UpdateChecker
 
         $this->io->writeError('<info>Done</info>', true, IO\IOInterface::VERBOSE);
 
-        return new Entity\Result\UpdateCheckResult($result->getOutdatedPackages(), $excludedPackages);
+        return new Entity\Result\UpdateCheckResult(
+            $result->getOutdatedPackages(),
+            $excludedPackages,
+            $this->lookupRootPackage(),
+        );
     }
 
     /**
@@ -235,5 +239,16 @@ final class UpdateChecker
         $event = new Event\PostUpdateCheckEvent($result);
 
         $this->composer->getEventDispatcher()->dispatch($event->getName(), $event);
+    }
+
+    private function lookupRootPackage(): ?Entity\Package\InstalledPackage
+    {
+        $rootPackageName = $this->composer->getPackage()->getName();
+
+        if ('__root__' === $rootPackageName || '' === $rootPackageName) {
+            return null;
+        }
+
+        return new Entity\Package\InstalledPackage($rootPackageName);
     }
 }


### PR DESCRIPTION
This PR rewrites the handling of the current root package used to perform the update check. It is now stored inside the `UpdateCheckResult` to make it easier to carry it around.