### PR TITLE
[FEATURE] Introduce reporter for MS Teams

### DIFF
--- a/src/Entity/Package/OutdatedPackage.php
+++ b/src/Entity/Package/OutdatedPackage.php
@@ -79,7 +79,7 @@ final class OutdatedPackage implements Package
 
     public function getHighestSeverityLevel(): ?Entity\Security\SeverityLevel
     {
-        if ([] === $this->securityAdvisories) {
+        if (!$this->isInsecure()) {
             return null;
         }
 
@@ -101,6 +101,9 @@ final class OutdatedPackage implements Package
         return $this;
     }
 
+    /**
+     * @phpstan-assert-if-true !null $this->getHighestSeverityLevel()
+     */
     public function isInsecure(): bool
     {
         return [] !== $this->securityAdvisories;

--- a/src/Entity/Report/Dto/TeamsAction.php
+++ b/src/Entity/Report/Dto/TeamsAction.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/composer-update-check".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\ComposerUpdateCheck\Entity\Report\Dto;
+
+use JsonSerializable;
+
+use function array_filter;
+
+/**
+ * TeamsAction.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class TeamsAction implements JsonSerializable
+{
+    /**
+     * @param list<string>|null $targetElements
+     */
+    private function __construct(
+        public readonly string $type,
+        public readonly string $id,
+        public readonly ?array $targetElements = null,
+        public readonly ?string $title = null,
+    ) {}
+
+    /**
+     * @param list<string> $targetElements
+     */
+    public static function toggleVisibility(string $id, string $title, array $targetElements): self
+    {
+        return new self(
+            type: 'Action.ToggleVisibility',
+            id: $id,
+            targetElements: $targetElements,
+            title: $title,
+        );
+    }
+
+    /**
+     * @return array{
+     *     type: string,
+     *     id: string,
+     *     targetElements?: list<string>,
+     *     title?: string,
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        $action = [
+            'type' => $this->type,
+            'id' => $this->id,
+            'targetElements' => $this->targetElements,
+            'title' => $this->title,
+        ];
+
+        return array_filter($action, static fn (mixed $value) => null !== $value);
+    }
+}

--- a/src/Entity/Report/Dto/TeamsAttachment.php
+++ b/src/Entity/Report/Dto/TeamsAttachment.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/composer-update-check".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\ComposerUpdateCheck\Entity\Report\Dto;
+
+use JsonSerializable;
+
+/**
+ * TeamsAttachment.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class TeamsAttachment implements JsonSerializable
+{
+    /**
+     * @param array<string, mixed> $content
+     */
+    private function __construct(
+        public readonly string $contentType,
+        public readonly array $content,
+    ) {}
+
+    /**
+     * @param list<TeamsContent> $body
+     * @param list<TeamsAction>  $actions
+     */
+    public static function adaptiveCard(array $body, string $fallbackText, array $actions = []): self
+    {
+        return new self(
+            'application/vnd.microsoft.card.adaptive',
+            [
+                'type' => 'AdaptiveCard',
+                'version' => '1.2',
+                'body' => $body,
+                'msteams' => [
+                    'width' => 'Full',
+                ],
+                'fallbackText' => $fallbackText,
+                'actions' => $actions,
+            ],
+        );
+    }
+
+    /**
+     * @return array{
+     *     contentType: string,
+     *     content: array<string, mixed>,
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'contentType' => $this->contentType,
+            'content' => $this->content,
+        ];
+    }
+}

--- a/src/Entity/Report/Dto/TeamsContent.php
+++ b/src/Entity/Report/Dto/TeamsContent.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/composer-update-check".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\ComposerUpdateCheck\Entity\Report\Dto;
+
+use JsonSerializable;
+
+use function array_filter;
+
+/**
+ * TeamsContent.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class TeamsContent implements JsonSerializable
+{
+    /**
+     * @param list<TeamsTableColumn>|null $columns
+     * @param list<TeamsFact>|null        $facts
+     * @param list<self>|null             $items
+     * @param list<TeamsTableRow>|null    $rows
+     */
+    private function __construct(
+        public readonly string $type,
+        public readonly ?array $columns = null,
+        public readonly ?array $facts = null,
+        public readonly ?bool $firstRowAsHeader = null,
+        public readonly ?string $gridStyle = null,
+        public readonly ?string $id = null,
+        public readonly ?bool $isVisible = null,
+        public readonly ?array $items = null,
+        public readonly ?array $rows = null,
+        public readonly ?string $size = null,
+        public readonly ?string $spacing = null,
+        public readonly ?string $text = null,
+        public readonly ?string $weight = null,
+        public readonly ?bool $wrap = null,
+    ) {}
+
+    /**
+     * @param list<self> $items
+     */
+    public static function container(
+        array $items,
+        bool $isVisible = true,
+        string $id = null,
+        string $spacing = null,
+    ): self {
+        return new self(
+            type: 'Container',
+            id: $id,
+            isVisible: $isVisible,
+            items: $items,
+            spacing: $spacing,
+        );
+    }
+
+    /**
+     * @param list<TeamsFact> $facts
+     */
+    public static function factSet(array $facts, string $spacing = null): self
+    {
+        return new self(
+            type: 'FactSet',
+            facts: $facts,
+            spacing: $spacing,
+        );
+    }
+
+    /**
+     * @param list<TeamsTableColumn> $columns
+     * @param list<TeamsTableRow>    $rows
+     */
+    public static function table(
+        array $columns,
+        array $rows,
+        bool $firstRowAsHeader = false,
+        string $gridStyle = null,
+    ): self {
+        return new self(
+            type: 'Table',
+            columns: $columns,
+            firstRowAsHeader: $firstRowAsHeader,
+            gridStyle: $gridStyle,
+            rows: $rows,
+        );
+    }
+
+    public static function textBlock(
+        string $text,
+        bool $wrap = false,
+        string $size = null,
+        string $spacing = null,
+        string $weight = null,
+    ): self {
+        return new self(
+            type: 'TextBlock',
+            size: $size,
+            spacing: $spacing,
+            text: $text,
+            weight: $weight,
+            wrap: $wrap,
+        );
+    }
+
+    /**
+     * @return array{
+     *     type: string,
+     *     columns?: list<TeamsTableColumn>,
+     *     facts?: list<TeamsFact>,
+     *     firstRowAsHeader?: bool,
+     *     gridStyle?: string,
+     *     id?: string,
+     *     isVisible?: bool,
+     *     items?: list<self>,
+     *     rows?: list<TeamsTableRow>,
+     *     size?: string,
+     *     spacing?: string,
+     *     text?: string,
+     *     weight?: string,
+     *     wrap?: bool,
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        $body = [
+            'type' => $this->type,
+            'columns' => $this->columns,
+            'facts' => $this->facts,
+            'firstRowAsHeader' => $this->firstRowAsHeader,
+            'gridStyle' => $this->gridStyle,
+            'id' => $this->id,
+            'isVisible' => $this->isVisible,
+            'items' => $this->items,
+            'rows' => $this->rows,
+            'size' => $this->size,
+            'spacing' => $this->spacing,
+            'text' => $this->text,
+            'weight' => $this->weight,
+            'wrap' => $this->wrap,
+        ];
+
+        return array_filter($body, static fn (mixed $value) => null !== $value);
+    }
+}

--- a/src/Entity/Report/Dto/TeamsFact.php
+++ b/src/Entity/Report/Dto/TeamsFact.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/composer-update-check".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\ComposerUpdateCheck\Entity\Report\Dto;
+
+use JsonSerializable;
+
+/**
+ * TeamsFact.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class TeamsFact implements JsonSerializable
+{
+    public function __construct(
+        public readonly string $title,
+        public readonly string $value,
+    ) {}
+
+    /**
+     * @return array{
+     *     title: string,
+     *     value: string,
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'title' => $this->title,
+            'value' => $this->value,
+        ];
+    }
+}

--- a/src/Entity/Report/Dto/TeamsTableCell.php
+++ b/src/Entity/Report/Dto/TeamsTableCell.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/composer-update-check".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\ComposerUpdateCheck\Entity\Report\Dto;
+
+use JsonSerializable;
+
+/**
+ * TeamsTableCell.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class TeamsTableCell implements JsonSerializable
+{
+    /**
+     * @param list<TeamsContent> $items
+     */
+    public function __construct(
+        public readonly array $items,
+    ) {}
+
+    /**
+     * @return array{
+     *     type: string,
+     *     items: list<TeamsContent>,
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'type' => 'TableCell',
+            'items' => $this->items,
+        ];
+    }
+}

--- a/src/Entity/Report/Dto/TeamsTableColumn.php
+++ b/src/Entity/Report/Dto/TeamsTableColumn.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/composer-update-check".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\ComposerUpdateCheck\Entity\Report\Dto;
+
+use JsonSerializable;
+
+/**
+ * TeamsTableColumn.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class TeamsTableColumn implements JsonSerializable
+{
+    /**
+     * @param positive-int $width
+     */
+    public function __construct(
+        public readonly int $width,
+    ) {}
+
+    /**
+     * @return array{
+     *     type: string,
+     *     width: positive-int,
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'type' => 'TableColumnDefinition',
+            'width' => $this->width,
+        ];
+    }
+}

--- a/src/Entity/Report/Dto/TeamsTableRow.php
+++ b/src/Entity/Report/Dto/TeamsTableRow.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/composer-update-check".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\ComposerUpdateCheck\Entity\Report\Dto;
+
+use JsonSerializable;
+
+use function array_filter;
+
+/**
+ * TeamsTableRow.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class TeamsTableRow implements JsonSerializable
+{
+    /**
+     * @param list<TeamsTableCell> $cells
+     */
+    public function __construct(
+        public readonly array $cells,
+        public readonly ?string $spacing = null,
+        public readonly ?string $horizontalCellContentAlignment = null,
+        public readonly ?string $verticalCellContentAlignment = null,
+    ) {}
+
+    /**
+     * @return array{
+     *     type: string,
+     *     cells: list<TeamsTableCell>,
+     *     spacing?: string,
+     *     horizontalCellContentAlignment?: string,
+     *     verticalCellContentAlignment?: string,
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        $row = [
+            'type' => 'TableRow',
+            'cells' => $this->cells,
+            'spacing' => $this->spacing,
+            'horizontalCellContentAlignment' => $this->horizontalCellContentAlignment,
+            'verticalCellContentAlignment' => $this->verticalCellContentAlignment,
+        ];
+
+        return array_filter($row, static fn (mixed $value) => null !== $value);
+    }
+}

--- a/src/Entity/Report/TeamsReport.php
+++ b/src/Entity/Report/TeamsReport.php
@@ -1,0 +1,400 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/composer-update-check".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\ComposerUpdateCheck\Entity\Report;
+
+use EliasHaeussler\ComposerUpdateCheck\Entity;
+use JsonSerializable;
+
+use function array_fill;
+use function count;
+use function sprintf;
+
+/**
+ * TeamsReport.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class TeamsReport implements JsonSerializable
+{
+    private const SECURITY_ADVISORIES_CONTAINER_ID = 'securityAdvisories';
+
+    /**
+     * @param list<Dto\TeamsAttachment> $attachments
+     */
+    private function __construct(
+        public readonly string $type,
+        public readonly array $attachments,
+    ) {}
+
+    public static function create(Entity\Result\UpdateCheckResult $result): self
+    {
+        return new self(
+            'message',
+            self::createAttachments($result),
+        );
+    }
+
+    /**
+     * @return list<Dto\TeamsAttachment>
+     */
+    private static function createAttachments(Entity\Result\UpdateCheckResult $result): array
+    {
+        $attachment = Dto\TeamsAttachment::adaptiveCard(
+            self::createCardBody($result),
+            self::createFallbackText($result),
+            self::createCardActions($result),
+        );
+
+        return [$attachment];
+    }
+
+    /**
+     * @return list<Dto\TeamsContent>
+     */
+    private static function createCardBody(Entity\Result\UpdateCheckResult $result): array
+    {
+        $rootPackageName = $result->getRootPackage()?->getName();
+        $numberOfOutdatedPackages = 0;
+        $numberOfInsecurePackages = 0;
+        $highestSeverityLevels = [];
+
+        // Count outdated and insecure packages
+        foreach ($result->getOutdatedPackages() as $outdatedPackage) {
+            ++$numberOfOutdatedPackages;
+
+            if ($outdatedPackage->isInsecure()) {
+                ++$numberOfInsecurePackages;
+                $highestSeverityLevels[] = $outdatedPackage->getHighestSeverityLevel();
+            }
+        }
+
+        // Add title
+        $contents = [
+            Dto\TeamsContent::textBlock(
+                text: sprintf(
+                    '%d package%s%s %s outdated',
+                    $numberOfOutdatedPackages,
+                    1 !== $numberOfOutdatedPackages ? 's' : '',
+                    $numberOfInsecurePackages > 0 ? sprintf(' (%d insecure)', $numberOfInsecurePackages) : '',
+                    1 !== $numberOfOutdatedPackages ? 'are' : 'is',
+                ),
+                wrap: true,
+                size: 'Large',
+                weight: 'Bolder',
+            ),
+        ];
+
+        // Add summary
+        if (null !== $rootPackageName) {
+            $contents[] = Dto\TeamsContent::textBlock(
+                text: sprintf(
+                    'Project **%s** has **%d outdated package%s**.',
+                    $rootPackageName,
+                    $numberOfOutdatedPackages,
+                    1 !== $numberOfOutdatedPackages ? 's' : '',
+                ),
+                wrap: true,
+            );
+
+            if ([] !== $highestSeverityLevels) {
+                $highestSeverityLevel = Entity\Security\SeverityLevel::getHighestSeverityLevel(...$highestSeverityLevels);
+                $contents[] = Dto\TeamsContent::textBlock(
+                    text: sprintf(
+                        '%s marked as **insecure** with a %sseverity of **%s**.',
+                        $numberOfInsecurePackages === $numberOfOutdatedPackages
+                            ? ($numberOfInsecurePackages > 1 ? 'They are' : 'It is')
+                            : sprintf(
+                                '%d of them %s',
+                                $numberOfInsecurePackages,
+                                $numberOfInsecurePackages > 1 ? 'is' : 'are',
+                            ),
+                        $numberOfInsecurePackages > 1 ? 'highest' : '',
+                        $highestSeverityLevel->value,
+                    ),
+                    wrap: true,
+                    spacing: 'None',
+                );
+            }
+        }
+
+        // Add table with outdated packages
+        $contents[] = self::createTableWithOutdatedPackages($result);
+
+        // Add container with security advisories
+        if ($numberOfInsecurePackages > 0) {
+            $contents[] = self::createSecurityAdvisoriesContainer($result);
+        }
+
+        return $contents;
+    }
+
+    private static function createTableWithOutdatedPackages(Entity\Result\UpdateCheckResult $result): Dto\TeamsContent
+    {
+        $rowCells = [];
+        $rowHeaders = [
+            'Package',
+            'Current version',
+            'New version',
+        ];
+
+        if ($result->hasInsecureOutdatedPackages()) {
+            $rowHeaders[] = 'Security advisory';
+        }
+
+        foreach ($rowHeaders as $rowHeader) {
+            $rowCells[] = new Dto\TeamsTableCell(
+                [
+                    Dto\TeamsContent::textBlock(
+                        text: $rowHeader,
+                        wrap: true,
+                    ),
+                ],
+            );
+        }
+
+        $columns = array_fill(0, count($rowHeaders), new Dto\TeamsTableColumn(1));
+        $rows = [
+            new Dto\TeamsTableRow(
+                cells: $rowCells,
+                spacing: 'None',
+                horizontalCellContentAlignment: 'Left',
+                verticalCellContentAlignment: 'Top',
+            ),
+        ];
+
+        // Add table rows
+        foreach ($result->getOutdatedPackages() as $outdatedPackage) {
+            $cells = [
+                new Dto\TeamsTableCell(
+                    [
+                        Dto\TeamsContent::textBlock(
+                            text: sprintf('[%s](%s)', $outdatedPackage->getName(), $outdatedPackage->getProviderLink()),
+                            wrap: true,
+                        ),
+                    ],
+                ),
+                new Dto\TeamsTableCell(
+                    [
+                        Dto\TeamsContent::textBlock(
+                            text: $outdatedPackage->getOutdatedVersion()->toString(),
+                            wrap: true,
+                        ),
+                    ],
+                ),
+                new Dto\TeamsTableCell(
+                    [
+                        Dto\TeamsContent::textBlock(
+                            text: $outdatedPackage->getNewVersion()->toString(),
+                            wrap: true,
+                            weight: 'Bolder',
+                        ),
+                    ],
+                ),
+            ];
+
+            if ($outdatedPackage->isInsecure()) {
+                $severityLevel = $outdatedPackage->getHighestSeverityLevel();
+                $cells[] = new Dto\TeamsTableCell(
+                    [
+                        Dto\TeamsContent::textBlock(
+                            text: sprintf(
+                                '%s %s',
+                                self::getEmojiForSeverityLevel($severityLevel),
+                                $severityLevel->value,
+                            ),
+                            wrap: true,
+                        ),
+                    ],
+                );
+            }
+
+            $rows[] = new Dto\TeamsTableRow($cells);
+        }
+
+        return Dto\TeamsContent::table(
+            columns: $columns,
+            rows: $rows,
+            firstRowAsHeader: true,
+            gridStyle: 'default',
+        );
+    }
+
+    private static function createSecurityAdvisoriesContainer(Entity\Result\UpdateCheckResult $result): Dto\TeamsContent
+    {
+        $items = [
+            Dto\TeamsContent::textBlock(
+                text: 'Security advisories',
+                wrap: true,
+                size: 'Large',
+                weight: 'Bolder',
+            ),
+        ];
+
+        foreach ($result->getInsecureOutdatedPackages() as $insecurePackage) {
+            foreach ($insecurePackage->getSecurityAdvisories() as $securityAdvisory) {
+                $facts = [
+                    new Dto\TeamsFact('Package', $securityAdvisory->getPackageName()),
+                    new Dto\TeamsFact('Reported at', $securityAdvisory->getReportedAt()->format('Y-m-d')),
+                ];
+
+                if (null !== $securityAdvisory->getCVE()) {
+                    $facts[] = new Dto\TeamsFact('CVE', $securityAdvisory->getCVE());
+                }
+
+                $containerItems = [
+                    Dto\TeamsContent::textBlock(
+                        text: sprintf(
+                            '%s %s',
+                            self::getEmojiForSeverityLevel($securityAdvisory->getSeverity()),
+                            $securityAdvisory->getSanitizedTitle(),
+                        ),
+                        wrap: true,
+                        weight: 'Bolder',
+                    ),
+                    Dto\TeamsContent::factSet(
+                        facts: $facts,
+                        spacing: 'Small',
+                    ),
+                ];
+
+                if (null !== $securityAdvisory->getLink()) {
+                    $containerItems[] = Dto\TeamsContent::textBlock(
+                        text: sprintf('[Read more](%s)', $securityAdvisory->getLink()),
+                        wrap: true,
+                        weight: 'Small',
+                    );
+                }
+
+                $items[] = Dto\TeamsContent::container($containerItems);
+            }
+        }
+
+        return Dto\TeamsContent::container(
+            items: $items,
+            isVisible: false,
+            id: self::SECURITY_ADVISORIES_CONTAINER_ID,
+            spacing: 'Medium',
+        );
+    }
+
+    private static function createFallbackText(Entity\Result\UpdateCheckResult $result): string
+    {
+        $rootPackageName = $result->getRootPackage()?->getName();
+        $numberOfOutdatedPackages = 0;
+        $numberOfInsecurePackages = 0;
+        $highestSeverityLevels = [];
+        $addition = '';
+
+        // Count outdated and insecure packages
+        foreach ($result->getOutdatedPackages() as $outdatedPackage) {
+            ++$numberOfOutdatedPackages;
+
+            if ($outdatedPackage->isInsecure()) {
+                ++$numberOfInsecurePackages;
+                $highestSeverityLevels[] = $outdatedPackage->getHighestSeverityLevel();
+            }
+        }
+
+        if ([] !== $highestSeverityLevels) {
+            $highestSeverityLevel = Entity\Security\SeverityLevel::getHighestSeverityLevel(...$highestSeverityLevels);
+            $addition = sprintf(
+                ' %s marked as insecure with a %sseverity of "%s".',
+                $numberOfInsecurePackages === $numberOfOutdatedPackages
+                    ? ($numberOfInsecurePackages > 1 ? 'They are' : 'It is')
+                    : sprintf(
+                        '%d of them %s',
+                        $numberOfInsecurePackages,
+                        $numberOfInsecurePackages > 1 ? 'is' : 'are',
+                    ),
+                $numberOfInsecurePackages > 1 ? 'highest' : '',
+                $highestSeverityLevel->value,
+            );
+        }
+
+        if (null !== $rootPackageName) {
+            return sprintf(
+                'Project "%s" has %d outdated package%s.%s',
+                $rootPackageName,
+                $numberOfOutdatedPackages,
+                1 !== $numberOfOutdatedPackages ? 's' : '',
+                $addition,
+            );
+        }
+
+        return sprintf(
+            '%d package%s are currently outdated.%s',
+            $numberOfOutdatedPackages,
+            1 !== $numberOfOutdatedPackages ? 's' : '',
+            $addition,
+        );
+    }
+
+    /**
+     * @return list<Dto\TeamsAction>
+     */
+    private static function createCardActions(Entity\Result\UpdateCheckResult $result): array
+    {
+        if (!$result->hasInsecureOutdatedPackages()) {
+            return [];
+        }
+
+        $actionId = 'showSecurityAdvisories';
+
+        return [
+            Dto\TeamsAction::toggleVisibility(
+                $actionId,
+                'Show security advisories',
+                [
+                    self::SECURITY_ADVISORIES_CONTAINER_ID,
+                    $actionId,
+                ],
+            ),
+        ];
+    }
+
+    private static function getEmojiForSeverityLevel(Entity\Security\SeverityLevel $severityLevel): string
+    {
+        return match ($severityLevel) {
+            Entity\Security\SeverityLevel::Low => '⚪',
+            Entity\Security\SeverityLevel::Medium => '🟡',
+            Entity\Security\SeverityLevel::High => '🟠',
+            Entity\Security\SeverityLevel::Critical => '🔴',
+        };
+    }
+
+    /**
+     * @return array{
+     *     type: string,
+     *     attachments: list<Dto\TeamsAttachment>,
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'type' => $this->type,
+            'attachments' => $this->attachments,
+        ];
+    }
+}

--- a/src/Reporter/TeamsReporter.php
+++ b/src/Reporter/TeamsReporter.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/composer-update-check".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\ComposerUpdateCheck\Reporter;
+
+use Composer\IO;
+use EliasHaeussler\ComposerUpdateCheck\Entity;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception;
+use GuzzleHttp\Psr7;
+use GuzzleHttp\RequestOptions;
+use Symfony\Component\OptionsResolver;
+
+/**
+ * TeamsReporter.
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-3.0-or-later
+ */
+final class TeamsReporter implements Reporter
+{
+    public const NAME = 'teams';
+
+    private readonly OptionsResolver\OptionsResolver $resolver;
+
+    public function __construct(
+        private readonly Client $client,
+        private readonly IO\IOInterface $io,
+    ) {
+        $this->resolver = $this->createOptionsResolver();
+    }
+
+    public function report(Entity\Result\UpdateCheckResult $result, array $options): bool
+    {
+        ['url' => $url] = $this->resolver->resolve($options);
+
+        // Create report
+        $report = Entity\Report\TeamsReport::create($result);
+
+        // Send report
+        try {
+            $this->io->writeError('📤 Sending report to Teams... ', false, IO\IOInterface::VERBOSE);
+
+            $response = $this->client->post($url, [
+                RequestOptions::JSON => $report,
+            ]);
+            $successful = 202 === $response->getStatusCode();
+        } catch (Exception\GuzzleException) {
+            $successful = false;
+        }
+
+        if ($successful) {
+            $this->io->writeError('<info>Done</info>', true, IO\IOInterface::VERBOSE);
+        } else {
+            $this->io->writeError('<error>Failed</error>', true, IO\IOInterface::VERBOSE);
+        }
+
+        return $successful;
+    }
+
+    /**
+     * @throws OptionsResolver\Exception\ExceptionInterface
+     */
+    public function validateOptions(array $options): void
+    {
+        $this->resolver->resolve($options);
+    }
+
+    public static function getName(): string
+    {
+        return self::NAME;
+    }
+
+    private function createOptionsResolver(): OptionsResolver\OptionsResolver
+    {
+        $resolver = new OptionsResolver\OptionsResolver();
+
+        $resolver->define('url')
+            ->allowedTypes('string')
+            ->required()
+            ->normalize(
+                static fn (OptionsResolver\OptionsResolver $resolver, string $url) => new Psr7\Uri($url),
+            )
+        ;
+
+        return $resolver;
+    }
+}


### PR DESCRIPTION
This PR adds a new reporter to allow sending update check results to MS Teams. It serves as an enhanced version of https://github.com/eliashaeussler/composer-update-reporter/blob/1.3.3/src/Service/Teams.php.

## Examples

### Default view

![image](https://github.com/user-attachments/assets/26845d06-d86a-4633-a38e-35138a3cd8f2)

### Extended view with security advisories

![image](https://github.com/user-attachments/assets/f6d2701b-491c-4b7a-92e4-0d727ec5c7b7)
