### PR TITLE
[TASK] Use version 1.5 for adaptive card in teams report

### DIFF
--- a/src/Entity/Report/Dto/TeamsAttachment.php
+++ b/src/Entity/Report/Dto/TeamsAttachment.php
@@ -51,7 +51,7 @@ final class TeamsAttachment implements JsonSerializable
             'application/vnd.microsoft.card.adaptive',
             [
                 'type' => 'AdaptiveCard',
-                'version' => '1.2',
+                'version' => '1.5',
                 'body' => $body,
                 'msteams' => [
                     'width' => 'Full',


### PR DESCRIPTION
This PR raises the used version of adaptive cards in teams reports from 1.2 to 1.5, since we're using components that are available since 1.5 only.