### PR TITLE
[FEATURE] Allow passing additional data to teams report

### DIFF
--- a/src/Entity/Report/Dto/TeamsAttachment.php
+++ b/src/Entity/Report/Dto/TeamsAttachment.php
@@ -47,8 +47,12 @@ final class TeamsAttachment implements JsonSerializable
      *
      * @see https://github.com/microsoft/AdaptiveCards/blob/main/schemas/src/AdaptiveCard.json
      */
-    public static function adaptiveCard(array $body, string $fallbackText, array $actions = []): self
-    {
+    public static function adaptiveCard(
+        array $body,
+        string $fallbackText,
+        array $actions = [],
+        string $additionalData = '',
+    ): self {
         return new self(
             'application/vnd.microsoft.card.adaptive',
             [
@@ -60,6 +64,7 @@ final class TeamsAttachment implements JsonSerializable
                 ],
                 'fallbackText' => $fallbackText,
                 'actions' => $actions,
+                '$data' => $additionalData,
             ],
         );
     }

--- a/src/Entity/Report/TeamsReport.php
+++ b/src/Entity/Report/TeamsReport.php
@@ -46,23 +46,24 @@ final class TeamsReport implements JsonSerializable
         public readonly array $attachments,
     ) {}
 
-    public static function create(Entity\Result\UpdateCheckResult $result): self
+    public static function create(Entity\Result\UpdateCheckResult $result, string $additionalData = ''): self
     {
         return new self(
             'message',
-            self::createAttachments($result),
+            self::createAttachments($result, $additionalData),
         );
     }
 
     /**
      * @return list<Dto\TeamsAttachment>
      */
-    private static function createAttachments(Entity\Result\UpdateCheckResult $result): array
+    private static function createAttachments(Entity\Result\UpdateCheckResult $result, string $additionalData = ''): array
     {
         $attachment = Dto\TeamsAttachment::adaptiveCard(
             self::createCardBody($result),
             self::createFallbackText($result),
             self::createCardActions($result),
+            $additionalData,
         );
 
         return [$attachment];

--- a/src/Reporter/TeamsReporter.php
+++ b/src/Reporter/TeamsReporter.php
@@ -60,10 +60,10 @@ final class TeamsReporter implements Reporter
         }
 
         // Resolve configuration options
-        ['url' => $url] = $this->resolver->resolve($options);
+        ['url' => $url, 'additionalData' => $additionalData] = $this->resolver->resolve($options);
 
         // Create report
-        $report = Entity\Report\TeamsReport::create($result);
+        $report = Entity\Report\TeamsReport::create($result, $additionalData);
 
         // Send report
         try {
@@ -109,6 +109,11 @@ final class TeamsReporter implements Reporter
             ->normalize(
                 static fn (OptionsResolver\OptionsResolver $resolver, string $url) => new Psr7\Uri($url),
             )
+        ;
+
+        $resolver->define('additionalData')
+            ->allowedTypes('string')
+            ->default('')
         ;
 
         return $resolver;


### PR DESCRIPTION
This PR adds a new config option `additionalData` to the teams reporter. It is passed as `$data` property to the generated adaptive card attachment.