### PR TITLE
[FEATURE] Store additional metadata for excluded packages

### DIFF
--- a/src/Entity/Package/ExcludeReason.php
+++ b/src/Entity/Package/ExcludeReason.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/composer-update-check".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\ComposerUpdateCheck\Entity\Package;
+
+/**
+ * ExcludeReason.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+enum ExcludeReason
+{
+    case NoDev;
+    case Pattern;
+}

--- a/src/Entity/Package/ExcludedPackage.php
+++ b/src/Entity/Package/ExcludedPackage.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/composer-update-check".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\ComposerUpdateCheck\Entity\Package;
+
+use EliasHaeussler\ComposerUpdateCheck\Configuration;
+
+/**
+ * ExcludedPackage.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class ExcludedPackage implements Package
+{
+    /**
+     * @param non-empty-string $name
+     */
+    public function __construct(
+        private readonly string $name,
+        private readonly ExcludeReason $excludeReason,
+        private readonly ?Configuration\Options\PackageExcludePattern $excludePattern = null,
+    ) {}
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getExcludeReason(): ExcludeReason
+    {
+        return $this->excludeReason;
+    }
+
+    public function getExcludePattern(): ?Configuration\Options\PackageExcludePattern
+    {
+        return $this->excludePattern;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function jsonSerialize(): string
+    {
+        return $this->name;
+    }
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Entity/Result/UpdateCheckResult.php
+++ b/src/Entity/Result/UpdateCheckResult.php
@@ -39,13 +39,13 @@ final class UpdateCheckResult
     private readonly array $outdatedPackages;
 
     /**
-     * @var list<Entity\Package\Package>
+     * @var list<Entity\Package\ExcludedPackage>
      */
     private readonly array $excludedPackages;
 
     /**
      * @param list<Entity\Package\OutdatedPackage> $outdatedPackages
-     * @param list<Entity\Package\Package>         $excludedPackages
+     * @param list<Entity\Package\ExcludedPackage> $excludedPackages
      */
     public function __construct(
         array $outdatedPackages,
@@ -70,7 +70,7 @@ final class UpdateCheckResult
     }
 
     /**
-     * @return list<Entity\Package\Package>
+     * @return list<Entity\Package\ExcludedPackage>
      */
     public function getExcludedPackages(): array
     {

--- a/src/UpdateChecker.php
+++ b/src/UpdateChecker.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\ComposerUpdateCheck;
 
 use Composer\IO;
 
+use function array_fill_keys;
 use function array_keys;
 use function array_map;
 use function array_merge;
@@ -87,8 +88,8 @@ final class UpdateChecker
     }
 
     /**
-     * @param list<Entity\Package\Package> $packages
-     * @param list<Entity\Package\Package> $excludedPackages
+     * @param list<Entity\Package\Package>         $packages
+     * @param list<Entity\Package\ExcludedPackage> $excludedPackages
      *
      * @throws Exception\ComposerInstallFailed
      * @throws Exception\ComposerUpdateFailed
@@ -145,7 +146,7 @@ final class UpdateChecker
     }
 
     /**
-     * @return array{list<Entity\Package\Package>, list<Entity\Package\Package>}
+     * @return array{list<Entity\Package\Package>, list<Entity\Package\ExcludedPackage>}
      */
     private function resolvePackagesForUpdateCheck(Configuration\ComposerUpdateCheckConfig $config): array
     {
@@ -163,7 +164,7 @@ final class UpdateChecker
         if ($config->areDevPackagesIncluded()) {
             $requiredPackages = array_merge($requiredPackages, $requiredDevPackages);
         } else {
-            $excludedPackages = $requiredDevPackages;
+            $excludedPackages = array_fill_keys($requiredDevPackages, null);
 
             $this->io->writeError(['', '🚫 Skipped dev-requirements'], true, IO\IOInterface::VERBOSE);
 
@@ -184,7 +185,7 @@ final class UpdateChecker
 
         return [
             $this->mapPackageNamesToPackage($requiredPackages),
-            $this->mapPackageNamesToPackage($excludedPackages),
+            $this->mapExcludedPackages($excludedPackages),
         ];
     }
 
@@ -192,7 +193,7 @@ final class UpdateChecker
      * @param array<non-empty-string>                           $packages
      * @param list<Configuration\Options\PackageExcludePattern> $excludePatterns
      *
-     * @return array<non-empty-string>
+     * @return array<non-empty-string, Configuration\Options\PackageExcludePattern>
      */
     private function removeByExcludePatterns(
         array &$packages,
@@ -206,7 +207,7 @@ final class UpdateChecker
             function (string $package) use (&$excludedPackages, $excludePatterns, &$outputWasWritten) {
                 foreach ($excludePatterns as $excludePattern) {
                     if ($excludePattern->matches($package)) {
-                        $excludedPackages[] = $package;
+                        $excludedPackages[$package] = $excludePattern;
 
                         if ($this->io->isVerbose()) {
                             if (!$outputWasWritten) {
@@ -255,6 +256,27 @@ final class UpdateChecker
             static fn (string $packageName) => new Entity\Package\InstalledPackage($packageName),
             $packageNames,
         );
+    }
+
+    /**
+     * @param array<non-empty-string, Configuration\Options\PackageExcludePattern|null> $excludedPackages
+     *
+     * @return array<Entity\Package\ExcludedPackage>
+     */
+    private function mapExcludedPackages(array $excludedPackages): array
+    {
+        $packages = [];
+
+        foreach ($excludedPackages as $packageName => $excludePattern) {
+            $excludeReason = null === $excludePattern
+                ? Entity\Package\ExcludeReason::NoDev
+                : Entity\Package\ExcludeReason::Pattern
+            ;
+
+            $packages[] = new Entity\Package\ExcludedPackage($packageName, $excludeReason, $excludePattern);
+        }
+
+        return $packages;
     }
 
     private function dispatchPostUpdateCheckEvent(Entity\Result\UpdateCheckResult $result): void

--- a/tests/src/Entity/Result/UpdateCheckResultTest.php
+++ b/tests/src/Entity/Result/UpdateCheckResultTest.php
@@ -59,15 +59,13 @@ final class UpdateCheckResultTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function constructorSortsExcludedPackages(): void
     {
-        $bazPackage = new Src\Entity\Package\OutdatedPackage(
+        $bazPackage = new Src\Entity\Package\ExcludedPackage(
             'baz/baz',
-            new Src\Entity\Version('1.5.0'),
-            new Src\Entity\Version('1.7.2'),
+            Src\Entity\Package\ExcludeReason::NoDev,
         );
-        $fooPackage = new Src\Entity\Package\OutdatedPackage(
+        $fooPackage = new Src\Entity\Package\ExcludedPackage(
             'foo/foo',
-            new Src\Entity\Version('1.0.0'),
-            new Src\Entity\Version('1.0.5'),
+            Src\Entity\Package\ExcludeReason::NoDev,
         );
 
         $actual = new Src\Entity\Result\UpdateCheckResult([], [$fooPackage, $bazPackage]);

--- a/tests/src/UpdateCheckerTest.php
+++ b/tests/src/UpdateCheckerTest.php
@@ -130,8 +130,15 @@ final class UpdateCheckerTest extends Framework\TestCase
         $expected = new Src\Entity\Result\UpdateCheckResult(
             [],
             [
-                new Src\Entity\Package\InstalledPackage('doctrine/dbal'),
-                new Src\Entity\Package\InstalledPackage('symfony/http-kernel'),
+                new Src\Entity\Package\ExcludedPackage(
+                    'doctrine/dbal',
+                    Src\Entity\Package\ExcludeReason::NoDev,
+                ),
+                new Src\Entity\Package\ExcludedPackage(
+                    'symfony/http-kernel',
+                    Src\Entity\Package\ExcludeReason::Pattern,
+                    Src\Configuration\Options\PackageExcludePattern::byName('symfony/*'),
+                ),
             ],
         );
 


### PR DESCRIPTION
This PR introduces a new `ExcludedPackage` entity. It reflects the state of an excluded package and tracks additional metadata such as the exclude reason and possible excluded pattern.